### PR TITLE
Fix 'npm publish' workflow

### DIFF
--- a/.github/workflows/bbotd-package.yml
+++ b/.github/workflows/bbotd-package.yml
@@ -1,10 +1,12 @@
-name: Deploy NPM Package
+name: Build and publish bbotd package
 
 on:
   push:
     branches:
       - master
-      - fix/deploy-actions
+    paths:
+      - "packages/bbotd/**"
+      - ".github/workflows/bbotd-package.yml"
 
 jobs:
   publish:
@@ -24,12 +26,12 @@ jobs:
         working-directory: ./packages/bbotd
         run: npm install
 
-      - name: Build package 
+      - name: Build package
         working-directory: ./packages/bbotd
         run: npm run build
 
       - name: Publish to NPM
         working-directory: ./packages/bbotd
-        run: npm publish --provenance --access public
+        run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/react-example.yml
+++ b/.github/workflows/react-example.yml
@@ -1,10 +1,12 @@
-name: Deploy React example to GH Pages
+name: Build and deploy React example
 
 on:
   push:
-    branches: 
+    branches:
       - master
-      - fix/deploy-actions
+    paths:
+      - "examples/react-ts/**"
+      - ".github/workflows/react-example.yml"
 
 permissions:
   contents: write
@@ -12,7 +14,7 @@ permissions:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -35,4 +37,5 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./examples/react-ts/dist
-
+          destination_dir: react-ts
+          keep_files: true

--- a/README.md
+++ b/README.md
@@ -1,1 +1,70 @@
 # bezpieczenstwoPwr
+
+**An application for detecting anomalous behavior on websites.**
+
+This repository is a monorepo containing examples and packages. The main published package is located in the `packages/` folder (e.g., [bbotd on npm](https://www.npmjs.com/package/bbotd)), while example projects (such as the React TypeScript example) live in the `examples/` directory and are deployed via GitHub Pages.
+
+---
+
+## Overview
+
+The goal of **bezpieczenstwoPwr** is to detect suspicious or anomalous activities on web pages—for example, bot activity or challenges similar to CAPTCHA. It is conceived as a real-time authentication tool that leverages machine learning models and rigorous testing to ensure reliability.
+
+---
+
+## Requirements
+
+- **Machine Learning Model**
+  - Developed using data from Kaggle (e.g., mouse movement analysis)
+- **Testing**
+  - _Manual tests_
+  - _Automated tests_ (using in-house tools like scikit-learn)
+  - _End-to-end (e2e)_ tests
+- **Data Handling**
+  - Data anonymization from the frontend before sending it to the backend (as an additional feature)
+- **Real-Time Processing**
+  - The system is designed to operate potentially in real-time
+
+---
+
+## Data
+
+- **Kaggle:**  
+  Refer to the [Kaggle dataset](#) used as the basis for our machine learning model.
+
+---
+
+## Phase 2 & Future Work
+
+- **Metrics & Evaluation:**
+  - Gather and present meaningful metrics that evaluate the model's performance.
+  - Identify edge cases to understand when the model performs well and when it fails.
+- **Edge Case Scenarios:**
+  - Previous efforts included profiling typing patterns (tracking how input changes over time).
+  - In some tests, unconventional scenarios were considered (e.g., simulating a user with a cast on their arm or under the influence of alcohol).
+- **Next Steps:**
+  - Currently, the focus is on model training and displaying the initial results.
+  - Future enhancements may include additional features and real-time processing improvements.
+- **Resources:**
+  - Access to powerful virtual machines (with many processors and advanced GPUs) might be arranged if needed.
+
+---
+
+## How to Get Started
+
+- **For Package Development:**  
+  Navigate to the `packages/bbotd` directory and follow the individual package README instructions.
+- **For Example Projects:**  
+  Check the `examples/` folder (e.g., `examples/react-ts`) for projects that demonstrate real-world usage, deployed via GitHub Pages.
+
+---
+
+## Contributing
+
+Your contributions and feedback are welcome! Please open an issue or submit a pull request if you find any bugs or have suggestions for improvement.
+
+---
+
+## License
+
+This project is licensed under the MIT License.

--- a/README.pl.md
+++ b/README.pl.md
@@ -1,0 +1,75 @@
+# bezpieczenstwoPwr
+
+**Aplikacja wykrywająca anomalne zachowania na stronach internetowych**
+
+To repozytorium to monorepo, które zawiera przykłady oraz paczki. Główna paczka publikowana na [npm](https://www.npmjs.com/package/bbotd) znajduje się w folderze `packages/` (np. `packages/bbotd`), natomiast projekty demonstracyjne (takie jak przykład w React + TypeScript) znajdują się w folderze `examples/` i są wdrażane na GitHub Pages.
+
+---
+
+## Dostępne języki
+
+- [English](README.md)
+- [Polski](README.pl.md)
+
+## Opis
+
+Celem projektu **bezpieczenstwoPwr** jest wykrywanie podejrzanych lub anomalnych zachowań na stronach internetowych – na przykład aktywności botów lub zachowań przypominających działanie CAPTCHA. Projekt ma być narzędziem do uwierzytelniania w czasie rzeczywistym, wykorzystującym modele uczenia maszynowego oraz szerokie testy, zarówno manualne, jak i automatyczne.
+
+---
+
+## Wymagania
+
+- **Model Uczenia Maszynowego**
+  - Wykorzystuje dane z Kaggle, np. analiza ruchów myszy
+- **Testy**
+  - Testy manualne
+  - Testy automatyczne (w oparciu o narzędzia takie jak scikit-learn)
+  - Testy end-to-end (e2e)
+- **Przetwarzanie Danych**
+  - Anonimizacja danych przesyłanych z frontendu do backendu (jako dodatkowa funkcjonalność)
+- **Przetwarzanie w Czasie Rzeczywistym**
+  - Projekt zakłada możliwość działania w czasie rzeczywistym
+
+---
+
+## Dane
+
+- **Kaggle:**  
+  Odwołanie do [zbioru danych Kaggle](#) wykorzystywanego jako podstawa modelu uczenia maszynowego.
+
+---
+
+## Zajęcia 2 / Kolejne Kroki
+
+- **Metryki i Ocena:**
+  - Zbiór i przedstawienie odpowiednich metryk oceniających wydajność modelu.
+  - Analiza sytuacji brzegowych – co model potrafi, a kiedy nie działa prawidłowo.
+- **Sytuacje Brzegowe:**
+  - Wcześniejsze podejścia obejmowały profilowanie sposobu wpisywania tekstu (analiza zmian w czasie).
+  - Rozważono także nietypowe scenariusze, np. symulację sytuacji, gdy użytkownik ma założony gips lub pod wpływem alkoholu.
+- **Następne Kroki:**
+  - Na tym etapie skoncentrowano się na treningu modelu oraz prezentacji uzyskanych wyników.
+  - W przyszłości planowane są rozszerzenia funkcjonalności i ulepszenia w zakresie przetwarzania w czasie rzeczywistym.
+- **Zasoby:**
+  - W razie potrzeby można uzyskać dostęp do wirtualnych maszyn z dużą liczbą procesorów (choć z ograniczonym wsparciem dla grafiki).
+
+---
+
+## Jak Zacząć
+
+- **Rozwój Paczek:**  
+  Przejdź do folderu `packages/bbotd` i zapoznaj się z instrukcjami zawartymi w README paczki.
+- **Projekty Przykładowe:**  
+  Zajrzyj do folderu `examples/` (np. `examples/react-ts`), aby zobaczyć działanie projektu wdrożone na GitHub Pages.
+
+---
+
+## Wkład w Projekt
+
+Wszelkie wkłady (np. zgłaszanie błędów, sugestie oraz pull requesty) są mile widziane! Jeśli masz pomysł lub znalazłeś błąd, prosimy o otwarcie issue lub zgłoszenie zmian poprzez pull request.
+
+---
+
+## Licencja
+
+Projekt jest dostępny na licencji MIT.

--- a/examples/react-ts/index.html
+++ b/examples/react-ts/index.html
@@ -9,7 +9,9 @@
   <body>
     <div id="root"></div>
 
-    <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs/dist/tf.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs@4/dist/tf.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bbotd/dist/index.min.js"></script>
+
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/examples/react-ts/vite.config.ts
+++ b/examples/react-ts/vite.config.ts
@@ -1,7 +1,8 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
-})
+  base: "/bezpieczenstwoPwr/react-ts",
+});

--- a/packages/bbotd/.npmrc
+++ b/packages/bbotd/.npmrc
@@ -1,0 +1,1 @@
+//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}

--- a/packages/bbotd/README.md
+++ b/packages/bbotd/README.md
@@ -1,44 +1,65 @@
-# Usage
+# bbotd
 
-The package is available on [npm](https://www.npmjs.com/package/bbotd). But please imoprt it and [@tensorflow/tfjs](https://www.npmjs.com/package/@tensorflow/tfjs) via CDN in `<script>` tag.
+<p align="center"> <a href="https://www.npmjs.com/package/bbotd"> <img alt="npm version" src="https://img.shields.io/npm/v/bbotd?color=blue"> </a> <a href="https://www.npmjs.com/package/bbotd"> <img alt="npm downloads" src="https://img.shields.io/npm/dm/bbotd.svg"> </a> <a href="https://bundlephobia.com/result?p=bbotd"> <img alt="bundle size" src="https://badgen.net/bundlephobia/minzip/bbotd"> </a> <a href="https://github.com/Pawel-Jurek/bezpieczenstwoPwr"> <img alt="monorepo" src="https://img.shields.io/badge/monorepo-bezpieczenstwoPwr-blueviolet"> </a> </p>
 
-Example:
+**bbotd** is available on [npm](https://www.npmjs.com/package/bbotd), and is intended to be used in the browser via a `<script>` tag. It depends on [@tensorflow/tfjs](www.npmjs.com/package/@tensorflow/tfjs), whichshould also be imported via CDN.
+
+## 🚀 Quick start
+
+Include the following in your HTML:
 
 ```html
 <body>
-  <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs/dist/tf.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bbotd"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs@4/dist/tf.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bbotd/dist/index.min.js"></script>
 
-  <!-- your existing code here-->
+  <!-- Your code here -->
 </body>
 ```
 
-## Development
+> **💡 Note:** This package is intended for use in the browser. If you need Node.js support, let us know by opening an issue.
 
-Install dependencies via [npm](https://www.npmjs.com/)
+## 🛠 Development
+
+### Install dependencies
 
 ```bash
 npm install
 ```
 
-Static files must be served locally (until we find better way of providing them for tests).
+### Serve static files
 
-Serve static files from public directory via `serve`. The files become available under their corresponding paths, so e.g. `./public/models/1/model.json` becomes available under `http://localhost:3000/models/1/model.json`
+Until we implement a better method for serving test assets, you need to serve the `public/` directory locally. This allows access to models and other static resources:
 
 ```bash
 npx serve public
 ```
 
-Run tests. We use `vitest` as runner, it comes with helpful keybindings, e.g. clicking `r` while the vitest watch is running reruns all test suites.
+This makes files like `./public/models1/model.json` available at `http://llocalhost:3000/models/1/model.json`
+
+### Run tests
+
+We use [vitest](https://vitest.dev/) as our test runner. It supports interactive features -- like pressing `r` to re-run all test suites during watch mode:
 
 ```bash
 npm run test
 ```
 
-### Building package
+## 🏗 Build
 
-We utilize [rollup](ttps://rollupjs.org/) so the package is compatible between browsers. We build for [ES6](https://caniuse.com/es6) which makes it compatible with 97.4% users browsers, and 99.9%+ of browsers tracked by [caniuse](https://caniuse.com/).
+We use [Rollup](https://rollupjs.org/) to bundle the package for browsers. Output is build for modern ES6 environments, which ensures compatibility with:
+
+- ~97.7% of browsers globally
+- ~99.9% of browsers trached on [Can I Use](https://caniuse.com/?search=es6)
 
 ```bash
 npm run build
 ```
+
+## 📦 Publishing
+
+To publish a new version:
+
+1. Update `version` in `package.json`
+2. Create PR for a branch
+3. Wait for PR to be merged with master branch.

--- a/packages/bbotd/README.md
+++ b/packages/bbotd/README.md
@@ -35,8 +35,7 @@ Until we implement a better method for serving test assets, you need to serve th
 npx serve public
 ```
 
-This makes files like `./public/models1/model.json` available at `http://llocalhost:3000/models/1/model.json`
-
+This makes files like `./public/models1/model.json` available at `http://localhost:3000/models/1/model.json`
 ### Run tests
 
 We use [vitest](https://vitest.dev/) as our test runner. It supports interactive features -- like pressing `r` to re-run all test suites during watch mode:

--- a/packages/bbotd/README.md
+++ b/packages/bbotd/README.md
@@ -49,7 +49,7 @@ npm run test
 We use [Rollup](https://rollupjs.org/) to bundle the package for browsers. Output is build for modern ES6 environments, which ensures compatibility with:
 
 - ~97.7% of browsers globally
-- ~99.9% of browsers trached on [Can I Use](https://caniuse.com/?search=es6)
+- ~99.9% of browsers tracked on [Can I Use](https://caniuse.com/?search=es6)
 
 ```bash
 npm run build

--- a/packages/bbotd/package.json
+++ b/packages/bbotd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bbotd",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Detect basic bots on your website easily.",
   "keywords": [
     "bot-detection",


### PR DESCRIPTION
- tweak bbotd package workflow so it only triggers on changes to packages/bbotd/ directory
- tweak react-ts example build workflow so it only triggers on changes to examples/react-ts/
- change react-ts's gh-pages `destination_dir` - in the future it'll be merged with `/docs/` pages
-  update README 
- add README.pl.md
- fix react-ts `script` tags in `body`
- update `bbotd` package's README